### PR TITLE
add opt-in anonymous telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,8 @@
+# Telemetry Disclosure
+
+This package supports opt-in anonymous usage telemetry via [`@acamarata/telemetry`](https://github.com/acamarata/telemetry).
+
+Telemetry is **off by default**. No data is sent unless you set `ACAMARATA_TELEMETRY=1`.
+
+Full disclosure (what is sent, where it goes, how to disable):
+[github.com/acamarata/telemetry/blob/main/TELEMETRY.md](https://github.com/acamarata/telemetry/blob/main/TELEMETRY.md)

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@acamarata/eslint-config": "^0.1.0",
     "@acamarata/prettier-config": "^0.1.0",
+    "@acamarata/telemetry": "^0.1.0",
     "@acamarata/tsconfig": "^0.1.0",
     "@eslint/js": "^10.0.1",
     "@types/luxon": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@acamarata/prettier-config':
         specifier: ^0.1.0
         version: 0.1.0(prettier@3.8.1)
+      '@acamarata/telemetry':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@acamarata/tsconfig':
         specifier: ^0.1.0
         version: 0.1.0
@@ -92,6 +95,10 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       prettier: '>=3.0.0'
+
+  '@acamarata/telemetry@0.1.0':
+    resolution: {integrity: sha512-iP09ZD0bHencHLbv6kQZDgwN9crLCWGKxmiMrfJjhBCoWTgv4koSgg0Li/LFKwCCFluua6orj9fVeQ8eqcJXSQ==}
+    engines: {node: '>=20'}
 
   '@acamarata/tsconfig@0.1.0':
     resolution: {integrity: sha512-bgzyBak43mE+0HhduZX3cvaPjKcggtGGZZMjr35qtYWolsIWgZ9nx7OOswbVYoU35qoUv6rZ0mTK6GbZ8QTYjw==}
@@ -1571,6 +1578,8 @@ snapshots:
   '@acamarata/prettier-config@0.1.0(prettier@3.8.1)':
     dependencies:
       prettier: 3.8.1
+
+  '@acamarata/telemetry@0.1.0': {}
 
   '@acamarata/tsconfig@0.1.0': {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,14 @@ export { toHijri } from "./toHijri";
 export { formatHijriDate } from "./formatHijriDate";
 export { isValidHijriDate } from "./utils";
 export type { HijriDate, CalendarSystem, ConversionOptions } from "./types";
+
+// ── Opt-in anonymous telemetry ────────────────────────────────────────────────
+// Off by default. Enable: ACAMARATA_TELEMETRY=1
+// What is sent + how to disable: https://github.com/acamarata/telemetry/blob/main/TELEMETRY.md
+import('@acamarata/telemetry')
+  .then(({ track }) =>
+    track('load', { package: 'luxon-hijri', version: '3.0.3' }),
+  )
+  .catch(() => {
+    // telemetry not installed or disabled — that's fine
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,8 @@ export type { HijriDate, CalendarSystem, ConversionOptions } from "./types";
 // ── Opt-in anonymous telemetry ────────────────────────────────────────────────
 // Off by default. Enable: ACAMARATA_TELEMETRY=1
 // What is sent + how to disable: https://github.com/acamarata/telemetry/blob/main/TELEMETRY.md
-import('@acamarata/telemetry')
-  .then(({ track }) =>
-    track('load', { package: 'luxon-hijri', version: '3.0.3' }),
-  )
+import("@acamarata/telemetry")
+  .then(({ track }) => track("load", { package: "luxon-hijri", version: "3.0.3" }))
   .catch(() => {
     // telemetry not installed or disabled — that's fine
   });


### PR DESCRIPTION
## Summary
- Adds opt-in anonymous usage telemetry via `@acamarata/telemetry`
- Off by default — no data sent unless `ACAMARATA_TELEMETRY=1` is set
- Adds `TELEMETRY.md` disclosure and links from README

## What changes
- `src/index.ts`: dynamic-import `track('load', ...)` at module bottom
- `package.json`: `@acamarata/telemetry` in devDependencies
- `TELEMETRY.md`: disclosure file (new)

## Test plan
- [ ] Verify `ACAMARATA_TELEMETRY=1 node -e "import('luxon-hijri')"` emits a load event
- [ ] Verify without env var no ping is sent